### PR TITLE
POL-135: crawl referred committee for bill

### DIFF
--- a/crawler/spiders/manual_committee_spider.py
+++ b/crawler/spiders/manual_committee_spider.py
@@ -31,10 +31,10 @@ class ManualCommitteeSpider(SpiderTemplate):
     start_urls = ['https://google.com']
 
     def parse(self, response):
-
         def build_committee_with_meta(committee_name, house, num_members, description):
             committee = build_committee(committee_name, house)
-            committee.num_members = num_members
+            if num_members:
+                committee.num_members = num_members
             committee.description = description
             return committee
 
@@ -47,4 +47,3 @@ class ManualCommitteeSpider(SpiderTemplate):
         ]
         self.gql_client.bulk_merge(committees)
         LOGGER.info(f'merged {len(committees)} committees')
-

--- a/crawler/spiders/manual_committee_spider.py
+++ b/crawler/spiders/manual_committee_spider.py
@@ -31,12 +31,20 @@ class ManualCommitteeSpider(SpiderTemplate):
     start_urls = ['https://google.com']
 
     def parse(self, response):
+
+        def build_committee_with_meta(committee_name, house, num_members, description):
+            committee = build_committee(committee_name, house)
+            committee.num_members = num_members
+            committee.description = description
+            return committee
+
         committees = [
-            build_committee('衆議院本会議', 'REPRESENTATIVES', 465, description=main_desc),
-            build_committee('参議院本会議', 'COUNCILORS', 248, description=main_desc),
-            build_committee('衆議院憲法審査会', 'REPRESENTATIVES', None, description=kenpou_desc),
-            build_committee('衆議院情報監視審査会', 'REPRESENTATIVES', None, description=jouhou_desc),
-            build_committee('衆議院政治倫理審査会', 'REPRESENTATIVES', None, description=seiji_desc),
+            build_committee_with_meta('衆議院本会議', 'REPRESENTATIVES', 465, description=main_desc),
+            build_committee_with_meta('参議院本会議', 'COUNCILORS', 248, description=main_desc),
+            build_committee_with_meta('衆議院憲法審査会', 'REPRESENTATIVES', None, description=kenpou_desc),
+            build_committee_with_meta('衆議院情報監視審査会', 'REPRESENTATIVES', None, description=jouhou_desc),
+            build_committee_with_meta('衆議院政治倫理審査会', 'REPRESENTATIVES', None, description=seiji_desc),
         ]
         self.gql_client.bulk_merge(committees)
         LOGGER.info(f'merged {len(committees)} committees')
+

--- a/crawler/spiders/sangiin_committee_spider.py
+++ b/crawler/spiders/sangiin_committee_spider.py
@@ -29,7 +29,9 @@ class SangiinCommitteeSpider(SpiderTemplate):
         assert len(name_list) == len(num_members_list) == len(topics_list)
         committees = []
         for name, num_members, topics in zip(name_list, num_members_list, topics_list):
-            committee = build_committee(name, "COUNCILORS", num_members, topics)
+            committee = build_committee(name, "COUNCILORS")
+            committee.num_members = num_members
+            committee.topics = topics
             committees.append(committee)
         return committees
 

--- a/crawler/spiders/sangiin_spider.py
+++ b/crawler/spiders/sangiin_spider.py
@@ -65,16 +65,13 @@ class SangiinSpider(SpiderTemplate):
             return None
 
         def convert_committee_name_to_id(committee_name):
-            print(committee_name)
             op = Operation(Query)
             committee_filter = _CommitteeFilter(None)
             committee_filter.name = committee_name
             committees = op.committee(filter=committee_filter)
             committees.id()
             committee_id = self.gql_client.exec(op)['Committee']
-            print(committee_id)
             if len(committee_id) != 0:
-                print(committee_id[0])
                 return committee_id[0]['id']
             return None
 

--- a/crawler/spiders/sangiin_spider.py
+++ b/crawler/spiders/sangiin_spider.py
@@ -2,8 +2,7 @@ from logging import getLogger
 
 from crawler.spiders import SpiderTemplate
 from crawler.utils import extract_text, extract_full_href_or_none, build_bill, build_url, build_committee, \
-    to_neo4j_datetime, UrlTitle, \
-    BillCategory
+    to_neo4j_datetime, UrlTitle, BillCategory
 from politylink.graphql.schema import Url, Bill, House
 from politylink.utils import DateConverter
 

--- a/crawler/spiders/shugiin_committee_spider.py
+++ b/crawler/spiders/shugiin_committee_spider.py
@@ -32,7 +32,9 @@ class ShugiinCommitteeSpider(SpiderTemplate):
             except Exception as e:
                 LOGGER.warning(f'failed to parse row:\n{row.get()}\n{e}')
                 continue
-            committee = build_committee(committee_name, 'REPRESENTATIVES', num_members, topics)
+            committee = build_committee(committee_name, 'REPRESENTATIVES')
+            committee.num_members = num_members
+            committee.topics = topics
             committees.append(committee)
         return committees
 

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -105,16 +105,10 @@ def build_speech(minutes_id, order_in_minutes):
     return speech
 
 
-def build_committee(committee_name, house, num_members=None, topics=None, description=None):
+def build_committee(committee_name, house):
     committee = Committee(None)
     committee.name = committee_name
     committee.house = house
-    if num_members:
-        committee.num_members = num_members
-    if topics:
-        committee.topics = topics
-    if description:
-        committee.description = description
     committee.id = idgen(committee)
     return committee
 


### PR DESCRIPTION
参議院ページからBillの付託委員会情報を取得し、BillとCommitteeを紐づける（link）ように変更した。
link関数に与えるcommitteeのidを取得するために、クロールした委員会名でqueryを投げている。