### PR TITLE
"parse_name_str"内で重複していた"strip"を削除

### DIFF
--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -232,7 +232,7 @@ def parse_name_str(name_str):
     pattern = r'([^（）]+)（([^（）]+)）'
     if not re.fullmatch(pattern, name_str):
         raise ValueError(f'invalid name_str="{name_str}"')
-    parts = re.split('[ |　|（|）]', name_str.strip())
+    parts = re.split('[ |　|（|）]', name_str)
     if len(parts) == 3:
         return parts[0], '', parts[1], ''
     elif len(parts) == 5:


### PR DESCRIPTION
議員名の文字列に対して`parse_name_str`内で`strip()`関数が二度呼ばれていたので二度目を削除（動作結果に影響なし）。