### PR TITLE
POL-297: fix BillAction extraction

### DIFF
--- a/crawler/spiders/minutes_spider.py
+++ b/crawler/spiders/minutes_spider.py
@@ -183,19 +183,20 @@ class MinutesSpider(SpiderTemplate):
             if topic_id in bill_id2names.keys():
                 minutes_bill_id2names[topic_id] = bill_id2names[topic_id]
 
-        current_topic_id = None
+        current_topic_ids = None
         prev_bill_action_types = defaultdict(set)  # key: bill_id, value: set of action types
         for speech_rec in moderator_recs:
             speech = build_speech(minutes.id, int(speech_rec['speechOrder']))
             if any(topic in speech_rec['speech'] for topic in
                    minutes.topics + list(minutes_bill_id2names.values())):
-                current_topic_id = extract_topic_id(speech_rec['speech'], minutes_bill_id2names)
+                current_topic_ids = extract_topic_id(speech_rec['speech'], minutes_bill_id2names)
             bill_action_types = extract_bill_action_types(speech_rec['speech'])
-            if current_topic_id and bill_action_types:
-                for bill_action_type in bill_action_types:
-                    if bill_action_type not in prev_bill_action_types[current_topic_id]:
-                        bill_action = build_bill_action(current_topic_id, minutes.id, bill_action_type)
-                        bill_action.speech_id = speech.id  # only for link
-                        bill_action_lst.append(bill_action)
-                        prev_bill_action_types[current_topic_id].add(bill_action_type)
+            if current_topic_ids and bill_action_types:
+                for current_topic_id in current_topic_ids:
+                    for bill_action_type in bill_action_types:
+                        if bill_action_type not in prev_bill_action_types[current_topic_id]:
+                            bill_action = build_bill_action(current_topic_id, minutes.id, bill_action_type)
+                            bill_action.speech_id = speech.id  # only for link
+                            bill_action_lst.append(bill_action)
+                            prev_bill_action_types[current_topic_id].add(bill_action_type)
         return bill_action_lst

--- a/crawler/spiders/minutes_spider.py
+++ b/crawler/spiders/minutes_spider.py
@@ -7,7 +7,7 @@ import scrapy
 
 from crawler.spiders import SpiderTemplate
 from crawler.utils import build_minutes, build_speech, extract_topics, build_url, UrlTitle, build_minutes_activity, \
-    clean_speech, extract_topic_id, extract_bill_action_types, build_bill_action, is_moderator
+    clean_speech, extract_topic_ids, extract_bill_action_types, build_bill_action, is_moderator
 from politylink.elasticsearch.schema import MinutesText, SpeechText
 from politylink.nlp.keyphrase import KeyPhraseExtractor
 
@@ -189,7 +189,7 @@ class MinutesSpider(SpiderTemplate):
             speech = build_speech(minutes.id, int(speech_rec['speechOrder']))
             if any(topic in speech_rec['speech'] for topic in
                    minutes.topics + list(minutes_bill_id2names.values())):
-                current_topic_ids = extract_topic_id(speech_rec['speech'], minutes_bill_id2names)
+                current_topic_ids = extract_topic_ids(speech_rec['speech'], minutes_bill_id2names)
             bill_action_types = extract_bill_action_types(speech_rec['speech'])
             if current_topic_ids and bill_action_types:
                 for current_topic_id in current_topic_ids:

--- a/crawler/spiders/minutes_spider.py
+++ b/crawler/spiders/minutes_spider.py
@@ -183,7 +183,7 @@ class MinutesSpider(SpiderTemplate):
             if topic_id in bill_id2names.keys():
                 minutes_bill_id2names[topic_id] = bill_id2names[topic_id]
 
-        current_topic_ids = None
+        current_topic_ids = list()
         prev_bill_action_types = defaultdict(set)  # key: bill_id, value: set of action types
         for speech_rec in moderator_recs:
             speech = build_speech(minutes.id, int(speech_rec['speechOrder']))

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -226,25 +226,35 @@ def extract_topic_id(speech, bill_id2names):
             topic_ids.append(bill_id)
     if len(topic_ids) > 1:
         LOGGER.warning(f'found multiple topics: speech={speech}, topic_ids={topic_ids}')
-    return topic_ids[0] if len(topic_ids) == 1 else None
+    return topic_ids if len(topic_ids) > 0 else None
 
 
 def extract_bill_action_types(speech):
+    def is_bill_action_type(in_words, not_in_words=None):
+        if not_in_words is None:
+            not_in_words = []
+        is_type = False
+        for w in in_words:
+            is_type = is_type or (w in speech)
+        for w in not_in_words:
+            is_type = is_type and (w not in speech)
+        return is_type
+
     action_lst = []
-    if '説明' in speech and '省略' not in speech and '終わり' not in speech:
-        if '修正案' in speech:
+    if is_bill_action_type(['説明'], ['省略', '終わり', '趣旨説明は既に聴取']):
+        if is_bill_action_type(['修正案']):
             action_lst.append(BillActionType.AMENDMENT_EXPLANATION)
-        elif '附帯決議' in speech:
+        elif is_bill_action_type(['附帯決議']):
             action_lst.append(BillActionType.SUPPLEMENTARY_EXPLANATION)
-        elif '趣旨の説明' in speech or '趣旨説明' in speech:
+        elif is_bill_action_type(['趣旨の説明', '趣旨説明']):
             action_lst.append(BillActionType.BILL_EXPLANATION)
-    if '質疑' in speech:
+    if is_bill_action_type(['質疑']):
         action_lst.append(BillActionType.QUESTION)
-    if '討論' in speech:
+    if is_bill_action_type(['討論']):
         action_lst.append(BillActionType.DEBATE)
-    if '採決' in speech:
+    if is_bill_action_type(['採決']):
         action_lst.append(BillActionType.VOTE)
-    if '委員長の報告' in speech:
+    if is_bill_action_type(['委員長の報告']):
         action_lst.append(BillActionType.REPORT)
     return action_lst
 
@@ -255,7 +265,11 @@ def clean_speech(speech):
 
 def is_moderator(speech):
     speaker = speech.split()[0]
-    return '議長' in speaker or '委員長' in speaker
+    moderators = ['議長', '委員長', '会長', '主査']
+    ret = False
+    for m in moderators:
+        ret = ret or m in speaker
+    return ret
 
 
 def strip_join(str_list, sep=''):

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -225,7 +225,7 @@ def extract_topic_ids(speech, bill_id2names):
         if bill_name in speech:
             topic_ids.append(bill_id)
     if len(topic_ids) > 1:
-        LOGGER.warning(f'found multiple topics: speech={speech}, topic_ids={topic_ids}')
+        LOGGER.debug(f'found multiple topics: speech={speech}, topic_ids={topic_ids}')
     return topic_ids
 
 

--- a/tests/spiders/test_minutes_spider.py
+++ b/tests/spiders/test_minutes_spider.py
@@ -9,27 +9,28 @@ class TestMinutesSpider:
     def test_scrape_bill_actions(self):
         speeches = [
             'これより会議を始めます',
-            '法律案Xを議題とします',
-            '質疑に入ります',  # 2
-            '法律案Xの質疑を終わります',
-            '法律案Yを議題とします',
+            '法律案Aと法律案Bを一括して議題とします',
+            '趣旨説明は既に聴取しておりますので、質疑に入ります',  # 2
+            '法律案Aと法律案Bの質疑を終わります',
+            '法律案Cを議題とします',
             '採決に入ります',
-            '法律案Zを議題とします',
+            '法律案Dを議題とします',
             '趣旨説明お願いします',  # 7
             '採決に入ります',  # 8
             'お疲れ様でした',
         ]
         speech_recs = [self.build_rec(speech, i) for i, speech in enumerate(speeches)]
         minutes = build_minutes('猫ちゃん会議', datetime(2021, 1, 1))
-        minutes.topics = ['法律案X', '法律案Y', '法律案Z']
-        minutes.topic_ids = ['Bill:X', 'Bill:Z']
-        bill_id2name = {'Bill:X': '法律案X', 'Bill:Z': '法律案Z'}
+        minutes.topics = ['法律案A', '法律案B', '法律案C', '法律案D']
+        minutes.topic_ids = ['Bill:A', 'Bill:B', 'Bill:D']
+        bill_id2name = {'Bill:A': '法律案A', 'Bill:B': '法律案B', 'Bill:D': '法律案D'}
 
         bill_actions = MinutesSpider.scrape_bill_actions(speech_recs, minutes, bill_id2name)
-        assert len(bill_actions) == 3
-        self.assert_bill_action('Bill:X', minutes.id, 2, BillActionType.QUESTION, bill_actions[0])
-        self.assert_bill_action('Bill:Z', minutes.id, 7, BillActionType.BILL_EXPLANATION, bill_actions[1])
-        self.assert_bill_action('Bill:Z', minutes.id, 8, BillActionType.VOTE, bill_actions[2])
+        assert len(bill_actions) == 4
+        self.assert_bill_action('Bill:A', minutes.id, 2, BillActionType.QUESTION, bill_actions[0])
+        self.assert_bill_action('Bill:B', minutes.id, 2, BillActionType.QUESTION, bill_actions[1])
+        self.assert_bill_action('Bill:D', minutes.id, 7, BillActionType.BILL_EXPLANATION, bill_actions[2])
+        self.assert_bill_action('Bill:D', minutes.id, 8, BillActionType.VOTE, bill_actions[3])
 
     @staticmethod
     def assert_bill_action(bill_id, minutes_id, speech_order, bill_action_type, bill_action):


### PR DESCRIPTION
BillAction抽出について早めに直した方が良いところを直した。


- is_moderator()に「会長」と「主査」を追加

- 「趣旨説明は既に聴取」は趣旨説明と判定しないようにした

- 一回の発言に複数の法律案名が同時に出てきたときは、全ての法律案にBillActionをつける